### PR TITLE
Add job id to message metadata

### DIFF
--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -223,6 +223,7 @@ defmodule TaskBunny.Job do
   - delay: Set time in milliseconds to schedule the job enqueue time.
   - host: RabbitMQ host. By default it is automatically selected from configuration.
   - queue: RabbitMQ queue. By default it is automatically selected from configuration.
+  - id: Set a job ID to enable unique identification of jobs, e.g. as an idempotency key.
 
   """
   @spec enqueue(atom, any, keyword) :: :ok | {:error, any}
@@ -240,7 +241,8 @@ defmodule TaskBunny.Job do
     queue_data = Config.queue_for_job(job) || []
 
     host = options[:host] || queue_data[:host] || :default
-    {:ok, message} = Message.encode(job, payload)
+    message_options = Keyword.take(options, [:id])
+    {:ok, message} = Message.encode(job, payload, message_options)
 
     case options[:queue] || queue_data[:name] do
       nil -> raise QueueNotFoundError, job: job

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -14,27 +14,28 @@ defmodule TaskBunny.Message do
   @doc """
   Encode message body in JSON with job and argument.
   """
-  @spec encode(atom, any) :: {:ok, String.t()}
-  def encode(job, payload) do
-    data = message_data(job, payload)
+  @spec encode(atom, any, keyword | nil) :: {:ok, String.t()}
+  def encode(job, payload, options \\ []) do
+    data = message_data(job, payload, options)
     Poison.encode(data, pretty: true)
   end
 
   @doc """
   Similar to encode/2 but raises an exception on error.
   """
-  @spec encode!(atom, any) :: String.t()
-  def encode!(job, payload) do
-    data = message_data(job, payload)
+  @spec encode!(atom, any, keyword | nil) :: String.t()
+  def encode!(job, payload, options \\ []) do
+    data = message_data(job, payload, options)
     Poison.encode!(data, pretty: true)
   end
 
-  @spec message_data(atom, any) :: map
-  defp message_data(job, payload) do
+  @spec message_data(atom, any, keyword) :: map
+  defp message_data(job, payload, options) do
     %{
       "job" => encode_job(job),
       "payload" => payload,
-      "created_at" => DateTime.utc_now()
+      "created_at" => DateTime.utc_now(),
+      "id" => options[:id]
     }
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -21,5 +21,5 @@
   "rabbit_common": {:hex, :rabbit_common, "3.6.14", "dc134cd7228f656367e6e6ac88f1f4ef4a63d8a78a2238f52990a4de467708a1", [:make, :rebar3], [{:recon, "2.3.2", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm"},
   "recon": {:hex, :recon, "2.3.2", "4444c879be323b1b133eec5241cb84bd3821ea194c740d75617e106be4744318", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [], [], "hexpm"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [], [], "hexpm"}
 }

--- a/test/task_bunny/message_test.exs
+++ b/test/task_bunny/message_test.exs
@@ -10,8 +10,8 @@ defmodule TaskBunny.MessageTest do
 
   describe "encode/decode message body(payload)" do
     test "encode and decode payload" do
-      {:ok, encoded} = Message.encode(NameJob, %{"name" => "Joe"})
-      {:ok, %{"job" => job, "payload" => payload}} = Message.decode(encoded)
+      {:ok, encoded} = Message.encode(NameJob, %{"name" => "Joe"}, id: "some-id")
+      {:ok, %{"job" => job, "payload" => payload, "id" => "some-id"}} = Message.decode(encoded)
       assert job.perform(payload) == {:ok, "Joe"}
     end
 


### PR DESCRIPTION
Adds an `id` field to message metadata to support tracking of jobs uniquely.