### PR TITLE
Implement job lifecycle callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,24 +330,7 @@ You can also change the retry_interval by the number of failures.
 
 If a job fails more than `max_retry` times, the payload is sent to `jobs.[job_name].rejected` queue.
 
-When a job gets rejected the `on_reject` callback is called. By default it does nothing but you can override it.
-It's useful to execute recovery actions when a job fails (like sending an email to a customer for instance)
-
-It receives the body containing the payload of the rejected job plus the full error trace. It returns :ok
-
-```elixir
-defmodule FlakyJob do
-  use TaskBunny.Job
-  require Logger
-
-  def on_reject(_body) do
-     ...
-
-     :ok
-  end
-  ...
-end
-```
+When a job gets rejected the `on_reject` callback is called. See _Callbacks_ below for more information.
 
 #### Immediately Reject
 
@@ -370,6 +353,36 @@ defmodule SlowJob do
   ...
 end
 ```
+
+## Callbacks
+
+TaskBunny reports job transitions via callbacks:
+
+* `on_start` - called when the job starts
+* `on_success` - called when the job succeeds
+* `on_retry` - called when the job is re-enqueued for retry
+* `on_reject` - called when the job is rejected
+
+These callbacks do nothing by default but can be overridden. They are useful to execute recovery actions when a job fails (like sending an email to a customer for instance) or to report job status to external processes.
+
+The callbacks receive the body containing the payload of the job plus any error trace. They return `:ok`.
+
+#### Example
+
+```elixir
+defmodule FlakyJob do
+  use TaskBunny.Job
+  require Logger
+
+  def on_reject(_body) do
+     ...
+
+     :ok
+  end
+  ...
+end
+```
+
 
 ## Connection management
 

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -88,7 +88,28 @@ defmodule TaskBunny.Job do
   @callback perform(any) :: :ok | {:ok, any} | {:error, term}
 
   @doc """
-  Callback executed when a process gets rejected.
+  Callback executed when a job starts.
+
+  It receives the raw message structure including payload.
+  """
+  @callback on_start(any) :: :ok
+
+  @doc """
+  Callback executed when a job succeeds.
+
+  It receives the raw message structure including original payload.
+  """
+  @callback on_success(any) :: :ok
+
+  @doc """
+  Callback executed when a job gets requeued for retry.
+
+  It receives the raw message structure including original payload.
+  """
+  @callback on_retry(any) :: :ok
+
+  @doc """
+  Callback executed when a job gets rejected.
 
   It receives in input the whole error trace structure plus the orginal payload for inspection and recovery actions.
   """
@@ -163,10 +184,28 @@ defmodule TaskBunny.Job do
       def retry_interval(_failed_count), do: 300_000
 
       @doc false
+      @spec on_start(any) :: :ok
+      def on_start(_body), do: :ok
+
+      @doc false
+      @spec on_success(any) :: :ok
+      def on_success(_body), do: :ok
+
+      @doc false
+      @spec on_retry(any) :: :ok
+      def on_retry(_body), do: :ok
+
+      @doc false
       @spec on_reject(any) :: :ok
       def on_reject(_body), do: :ok
 
-      defoverridable timeout: 0, max_retry: 0, retry_interval: 1, on_reject: 1
+      defoverridable timeout: 0,
+                     max_retry: 0,
+                     retry_interval: 1,
+                     on_start: 1,
+                     on_success: 1,
+                     on_retry: 1,
+                     on_reject: 1
     end
   end
 

--- a/lib/task_bunny/worker.ex
+++ b/lib/task_bunny/worker.ex
@@ -149,7 +149,11 @@ defmodule TaskBunny.Worker do
       {:ok, decoded} ->
         Logger.debug(log_msg("basic_deliver", state, body: body))
 
-        JobRunner.invoke(decoded["job"], decoded["payload"], {body, meta})
+        job = decoded["job"]
+
+        start_callback(job, body)
+
+        JobRunner.invoke(job, decoded["payload"], {body, meta})
 
         {:noreply, %{state | runners: state.runners + 1}}
 
@@ -171,9 +175,7 @@ defmodule TaskBunny.Worker do
 
     case succeeded?(result) do
       true ->
-        Consumer.ack(state.channel, meta, true)
-
-        {:noreply, update_job_stats(state, :succeeded)}
+        handle_successful_job(state, body, meta)
 
       false ->
         handle_failed_job(state, body, meta, result)
@@ -223,6 +225,17 @@ defmodule TaskBunny.Worker do
   defp succeeded?({:ok, _}), do: true
   defp succeeded?(_), do: false
 
+  defp handle_successful_job(state, body, meta) do
+    {:ok, decoded} = Message.decode(body)
+    job = decoded["job"]
+
+    success_callback(job, body)
+
+    Consumer.ack(state.channel, meta, true)
+
+    {:noreply, update_job_stats(state, :succeeded)}
+  end
+
   defp handle_failed_job(state, body, meta, {:error, job_error}) do
     {:ok, decoded} = Message.decode(body)
     failed_count = Message.failed_count(decoded) + 1
@@ -249,6 +262,7 @@ defmodule TaskBunny.Worker do
       {:noreply, update_job_stats(state, :rejected)}
     else
       retry_message(job, state, new_body, meta, failed_count)
+      retry_callback(job, new_body)
       {:noreply, update_job_stats(state, :failed)}
     end
   end
@@ -279,6 +293,12 @@ defmodule TaskBunny.Worker do
     Consumer.ack(state.channel, meta, true)
     :ok
   end
+
+  defp start_callback(job, body), do: job.on_start(body)
+
+  defp success_callback(job, body), do: job.on_success(body)
+
+  defp retry_callback(job, body), do: job.on_retry(body)
 
   defp reject_callback(job, body), do: job.on_reject(body)
 

--- a/test/support/job_test_helper.ex
+++ b/test/support/job_test_helper.ex
@@ -24,16 +24,37 @@ defmodule TaskBunny.JobTestHelper do
 
     def retry_interval(_), do: RetryInterval.interval()
 
+    def on_start(body) do
+      pid = enqueuer_pid(body)
+      pid && send(pid, :on_start_callback_called)
+      :ok
+    end
+
+    def on_success(body) do
+      pid = enqueuer_pid(body)
+      pid && send(pid, :on_success_callback_called)
+      :ok
+    end
+
+    def on_retry(body) do
+      pid = enqueuer_pid(body)
+      pid && send(pid, :on_retry_callback_called)
+      :ok
+    end
+
     def on_reject(body) do
+      pid = enqueuer_pid(body)
+      pid && send(pid, :on_reject_callback_called)
+      :ok
+    end
+
+    defp enqueuer_pid(body) do
       ppid =
         body
         |> Poison.decode!()
         |> get_in(["payload", "ppid"])
 
-      ppid &&
-        ppid |> Base.decode64!() |> :erlang.binary_to_term() |> send(:on_reject_callback_called)
-
-      :ok
+      ppid && ppid |> Base.decode64!() |> :erlang.binary_to_term()
     end
   end
 


### PR DESCRIPTION
Adds `on_start`, `on_success`, and `on_retry` callbacks to complement
the existing `on_reject` callback and enable job lifecycle tracking.