### PR TITLE
chore: refactor worker to pass additional information to callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ erl_crash.dump
 .tool-versions
 
 /.elixir_ls
+/.vscode

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,6 +1,5 @@
-lib/mix/tasks/analyze.ex:1: Callback info about the 'Elixir.Mix.Task' behaviour is not available
-lib/mix/tasks/task_bunny.queue.reset.ex:1: Callback info about the 'Elixir.Mix.Task' behaviour is not available
 :0: Unknown function 'Elixir.Mix':shell/0
 :0: Unknown function 'Elixir.Mix.Task':run/1
 :0: Unknown function 'Elixir.Wobserver':register/2
-lib/task_bunny/message.ex:56: The variable _error@1 can never match since previous clauses completely covered the type {'ok','false' | 'nil' | 'true' | binary() | [any()] | number() | map()}
+lib/mix/tasks/analyze.ex:1: Callback info about the 'Elixir.Mix.Task' behaviour is not available
+lib/mix/tasks/task_bunny.queue.reset.ex:1: Callback info about the 'Elixir.Mix.Task' behaviour is not available

--- a/lib/task_bunny/job_error.ex
+++ b/lib/task_bunny/job_error.ex
@@ -1,6 +1,6 @@
 defmodule TaskBunny.JobError do
   @moduledoc """
-  A struct that holds an error information occured during the job processing.
+  A struct that holds an error information occurred during the job processing.
 
   ## Attributes
 

--- a/lib/task_bunny/job_runner.ex
+++ b/lib/task_bunny/job_runner.ex
@@ -2,5 +2,6 @@ defmodule TaskBunny.JobRunner do
   @moduledoc """
   Callbacks required to be provided by JobRunner modules.
   """
-  @callback invoke(atom, any, {any, any}) :: :ok | {:error, any}
+
+  @callback invoke(map, any) :: :ok | {:error, any}
 end

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -17,7 +17,7 @@ defmodule TaskBunny.Message do
   @spec encode(atom, any, keyword | nil) :: {:ok, String.t()}
   def encode(job, payload, options \\ []) do
     data = message_data(job, payload, options)
-    Jason.encode(data, pretty: true)
+    Jason.encode(data)
   end
 
   @doc """
@@ -26,11 +26,11 @@ defmodule TaskBunny.Message do
   @spec encode!(atom, any, keyword | nil) :: String.t()
   def encode!(job, payload, options \\ []) do
     data = message_data(job, payload, options)
-    Jason.encode!(data, pretty: true)
+    Jason.encode!(data)
   end
 
   @spec message_data(atom, any, keyword) :: map
-  defp message_data(job, payload, options) do
+  def message_data(job, payload, options) do
     %{
       "job" => encode_job(job),
       "payload" => payload,
@@ -105,8 +105,8 @@ defmodule TaskBunny.Message do
   @doc """
   Add an error log to message body.
   """
-  @spec add_error_log(String.t() | map, JobError.t()) :: String.t() | map
-  def add_error_log(message, error) when is_map(message) do
+  @spec add_error_log(map, JobError.t()) :: map
+  def add_error_log(message, error) do
     error = %{
       "result" => JobError.get_result_info(error),
       "failed_at" => DateTime.utc_now(),
@@ -118,13 +118,6 @@ defmodule TaskBunny.Message do
     Map.merge(message, %{"errors" => errors})
   end
 
-  def add_error_log(raw_message, error) do
-    raw_message
-    |> Jason.decode!()
-    |> add_error_log(error)
-    |> Jason.encode!(pretty: true)
-  end
-
   defp host do
     {:ok, hostname} = :inet.gethostname()
     List.to_string(hostname)
@@ -133,17 +126,11 @@ defmodule TaskBunny.Message do
   @doc """
   Returns a number of errors occurred for the message.
   """
-  @spec failed_count(String.t() | map) :: integer
-  def failed_count(message) when is_map(message) do
+  @spec failed_count(map) :: integer
+  def failed_count(message) do
     case message["errors"] do
       nil -> 0
       errors -> length(errors)
     end
-  end
-
-  def failed_count(raw_message) do
-    raw_message
-    |> Jason.decode!()
-    |> failed_count()
   end
 end

--- a/test/support/job_test_helper.ex
+++ b/test/support/job_test_helper.ex
@@ -30,19 +30,19 @@ defmodule TaskBunny.JobTestHelper do
       :ok
     end
 
-    def on_success(body) do
+    def on_success(body, _result) do
       pid = enqueuer_pid(body)
       pid && send(pid, :on_success_callback_called)
       :ok
     end
 
-    def on_retry(body) do
+    def on_retry(body, _result) do
       pid = enqueuer_pid(body)
       pid && send(pid, :on_retry_callback_called)
       :ok
     end
 
-    def on_reject(body) do
+    def on_reject(body, _result) do
       pid = enqueuer_pid(body)
       pid && send(pid, :on_reject_callback_called)
       :ok
@@ -51,7 +51,6 @@ defmodule TaskBunny.JobTestHelper do
     defp enqueuer_pid(body) do
       ppid =
         body
-        |> Jason.decode!()
         |> get_in(["payload", "ppid"])
 
       ppid && ppid |> Base.decode64!() |> :erlang.binary_to_term()

--- a/test/task_bunny/message_test.exs
+++ b/test/task_bunny/message_test.exs
@@ -46,7 +46,10 @@ defmodule TaskBunny.MessageTest do
   describe "add_error_log" do
     @tag timeout: 1000
     test "adds error information to the message" do
-      message = Message.encode!(NameJob, %{"name" => "Joe"})
+      message =
+        NameJob
+        |> Message.encode!(%{"name" => "Joe"})
+        |> Message.decode!()
 
       error = %JobError{
         error_type: :return_value,
@@ -56,12 +59,10 @@ defmodule TaskBunny.MessageTest do
         raw_body: "abcdefg"
       }
 
-      new_message = Message.add_error_log(message, error)
-      {:ok, %{"errors" => [added | _]}} = Message.decode(new_message)
-
-      assert added["result"]["error_type"] == ":return_value"
-      assert added["result"]["return_value"] == "{:error, :test_error}"
-      refute added["result"]["raw_body"]
+      assert %{"errors" => [added | _]} = Message.add_error_log(message, error)
+      assert added["result"][:error_type] == ":return_value"
+      assert added["result"][:return_value] == "{:error, :test_error}"
+      refute added["result"][:raw_body]
     end
   end
 end

--- a/test/task_bunny/status/worker_test.exs
+++ b/test/task_bunny/status/worker_test.exs
@@ -9,7 +9,7 @@ defmodule TaskBunny.Status.WorkerTest do
   @host :worker_test
   @supervisor :worker_test_supervisor
   @worker_supervisor :worker_test_worker_supervisor
-  @publisher :workert_test_publisher
+  @publisher :worker_test_publisher
   @queue1 "task_bunny.status.worker_test1"
   @queue2 "task_bunny.status.worker_test2"
 
@@ -118,7 +118,10 @@ defmodule TaskBunny.Status.WorkerTest do
       payload = %{"fail" => "fail"}
 
       RejectJob.enqueue(payload, host: @host, queue: @queue2)
-      capture_log(fn -> JobTestHelper.wait_for_perform() end)
+
+      capture_log(fn ->
+        JobTestHelper.wait_for_perform()
+      end)
 
       %{workers: workers} = TaskBunny.Status.overview(@supervisor)
       %{stats: stats} = find_worker(workers, @queue2)


### PR DESCRIPTION
This change also removes the unnecessary encode/decode cycles for the message body.